### PR TITLE
Add remediation links to rulepack validation reports

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,8 +3,10 @@ testpaths = tests
 addopts =
     --cov=fairy.cli
     --cov=fairy.rulepack
+    --cov=fairy.validation.rulepack_runner
     --cov-branch
     --cov-report=term-missing
     --cov-fail-under=35
 filterwarnings =
     ignore::DeprecationWarning
+    ignore:Module .* was never imported:coverage.exceptions.CoverageWarning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,17 +25,17 @@ def rulepack_path() -> Path:
 @pytest.fixture(scope="session")
 def samples_path() -> Path:
     # default demo location you created earlier
-    p = PROJECT_ROOT / "demos" / "scratchrun" / "samples.tsv"
+    p = PROJECT_ROOT / "tests" / "fixtures" / "preflight" / "samples.tsv"
     if not p.exists():
-        pytest.skip("demos/scratchrun/samples.tsv not found — add demo TSVs or skip.")
+        pytest.skip("tests/fixtures/preflight/samples.tsv not found")
     return p
 
 
 @pytest.fixture(scope="session")
 def files_path() -> Path:
-    p = PROJECT_ROOT / "demos" / "scratchrun" / "files.tsv"
+    p = PROJECT_ROOT / "tests" / "fixtures" / "preflight" / "files.tsv"
     if not p.exists():
-        pytest.skip("demos/scratchrun/files.tsv not found — add demo TSVs or skip.")
+        pytest.skip("tests/fixtures/preflight/files.tsv not found")
     return p
 
 

--- a/tests/fixtures/preflight/files.tsv
+++ b/tests/fixtures/preflight/files.tsv
@@ -1,0 +1,4 @@
+sample_id	layout	filename
+S1	        PAIRED	S1_R1.fastq.gz
+S1	        PAIRED	S1_R2.fastq.gz
+S999	    PAIRED	S999_R1.fastq.gz

--- a/tests/fixtures/preflight/samples.tsv
+++ b/tests/fixtures/preflight/samples.tsv
@@ -1,0 +1,3 @@
+sample_id	sample_title	organism	library_strategy	molecule	instrument_model	tissue	cell_line	cell_type	collection_date
+S1	        liver sample	human	RNA-Seq	total RNA	Illumina NovaSeq	liver			10/3/25
+S2	        heart	        human	RNA-Seq	total RNA	Illumina NovaSeq	heart			2025-10-02

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -32,4 +32,12 @@ def load_json(path: Path):
 
 
 def normalize_json(path: Path):
-    return _strip_volatile(load_json(path))
+    obj = load_json(path)
+
+    # normalize version bumps so goldens don't churn
+    try:
+        obj["_legacy"]["attestation"]["fairy_version"] = "<redacted>"
+    except Exception:
+        pass
+
+    return _strip_volatile(obj)

--- a/tests/test_remediation_links_unit.py
+++ b/tests/test_remediation_links_unit.py
@@ -1,0 +1,91 @@
+from fairy.validation.rulepack_runner import run_rulepack, write_markdown
+
+
+def test_remediation_links_appear_in_json_and_markdown(tmp_path):
+    # Arrange: write a tiny CSV
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text(
+        "primary_id,external_url\n"
+        ",https://example.org/1\n"
+        "ABC,https://example.org/2\n"
+        ",www.example.org/3\n"
+    )
+
+    # Rulepack dict (no YAML dependency needed)
+    rulepack = {
+        "id": "remediation-demo",
+        "version": "0.0.0",
+        "resources": [
+            {
+                "pattern": "data.csv",
+                "rules": [
+                    {
+                        "id": "primary_id_required",
+                        "type": "required",
+                        "severity": "fail",
+                        "columns": ["primary_id"],
+                        "remediation_link_column": "external_url",
+                        "remediation_link_label": "Open record",
+                    }
+                ],
+            }
+        ],
+    }
+
+    # Act
+    report = run_rulepack(
+        inputs_map={"default": csv_path},
+        rulepack=rulepack,
+        rp_path=tmp_path / "rulepack.yml",
+        now_iso="2025-01-01T00:00:00+00:00",
+    )
+
+    # Assert: JSON evidence contains remediation links (raw URL preserved)
+    evidence = report["resources"][0]["rules"][0]["evidence"]
+    assert evidence["nullish"]["rows_by_column"]["primary_id"] == [1, 3]
+    assert evidence["remediation"]["column"] == "external_url"
+    assert evidence["remediation"]["label"] == "Open record"
+    assert evidence["remediation"]["links"] == [
+        {"row": 1, "url": "https://example.org/1"},
+        {"row": 3, "url": "www.example.org/3"},
+    ]
+
+    # Assert: Markdown renders clickable link (adds https:// for www.*)
+    md = write_markdown(report)
+    assert "[Open record](https://example.org/1)" in md
+    assert "[Open record](https://www.example.org/3)" in md
+
+
+def test_no_remediation_block_when_not_configured(tmp_path):
+    csv_path = tmp_path / "data.csv"
+    csv_path.write_text("primary_id,external_url\n" ",https://example.org/1\n")
+
+    rulepack = {
+        "id": "no-remediation",
+        "version": "0.0.0",
+        "resources": [
+            {
+                "pattern": "data.csv",
+                "rules": [
+                    {
+                        "id": "primary_id_required",
+                        "type": "required",
+                        "severity": "fail",
+                        "columns": ["primary_id"],
+                        # no remediation_link_column / label
+                    }
+                ],
+            }
+        ],
+    }
+
+    report = run_rulepack(
+        inputs_map={"default": csv_path},
+        rulepack=rulepack,
+        rp_path=tmp_path / "rulepack.yml",
+        now_iso="2025-01-01T00:00:00+00:00",
+    )
+
+    evidence = report["resources"][0]["rules"][0]["evidence"]
+    assert "nullish" in evidence
+    assert "remediation" not in evidence


### PR DESCRIPTION
- Adds optional remediation_link_column + remediation_link_label to rulepack rules.  When a rule fails on specific rows, evidence includes a per-row remediation link list.
- Markdown validate report renders remediation links as clickable URLs (auto-prefixes https:// when missing).
- Tests: pytest -q and/or run fairy validate --inputs default=<csv> --rulepack <rulepack> --report-md out.md and confirm remediation links show for failing rows.