### PR TITLE
Normalize scheme-less www URLs in URL validator

### DIFF
--- a/src/fairy/validation/checks.py
+++ b/src/fairy/validation/checks.py
@@ -274,14 +274,22 @@ def _url_ok(v: Any, schemes: set[str]) -> bool:
     if pd.isna(v):
         return True
     try:
-        s = str(v)
+        s = str(v).strip()
     except Exception:
         return False
+
+    if s.lower().startswith("www."):
+        s = "https://" + s
+
     parts = urlsplit(s)
-    if not parts.scheme or not _SCHEME_RE.match(parts.scheme):
+    scheme = (parts.scheme or "").lower()
+
+    if not scheme or not _SCHEME_RE.match(scheme):
         return False
-    if schemes and parts.scheme not in schemes:
+
+    if schemes and scheme not in {x.lower() for x in schemes}:
         return False
+
     return bool(parts.netloc or parts.path)
 
 

--- a/tests/test_rule_validators.py
+++ b/tests/test_rule_validators.py
@@ -78,6 +78,19 @@ def test_column_url_schemes_and_syntax_only():
     assert [s.row for s in res.samples] == [3, 4]
 
 
+def test_column_url_accepts_www_without_scheme_by_normalizing():
+    df = pd.DataFrame({"u": ["www.example.org/path", "www.example.org", None]})
+    res = column_url(df, column="u", schemes=("http", "https"))
+    # After normalization, www.* should be treated as https://www.*
+    assert res is None
+
+
+def test_column_url_trims_whitespace_before_validation():
+    df = pd.DataFrame({"u": [" https://example.org/x ", "  http://example.org/y  ", None]})
+    res = column_url(df, column="u", schemes=("http", "https"))
+    assert res is None
+
+
 def test_column_non_empty_trimmed_warns_on_blank_and_na():
     df = pd.DataFrame({"t": ["  ", "x", None, " y "]})
     res = column_non_empty_trimmed(df, column="t", level="warn")


### PR DESCRIPTION
- Trim leading/trailing whitespace before URL validation
- Treat www.* as a valid web URL by normalizing to https://… (so links are actionable)
- Normalize scheme comparisons to be case-insensitive