### PR TITLE
Docs: clarify README command distinctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ code .tmp/penguins_report.md
 - **UI (fairy-lab)**: local project workspaces, guided fixes, visual workflow, export bundles.
   → https://github.com/yuummmer/fairy-lab
 
-- **CLI (this repo)**: run `fairy preflight` / `fairy validate` against a rulepack, review JSON/Markdown reports, iterate until submission-ready.
+- **CLI (this repo)**: run `fairy preflight` (human-friendly default) or `fairy validate` (engine command) against a rulepack, review JSON/Markdown reports, iterate until submission-ready.
+
+  **Command overview**: `validate` = checks; `preflight` = checks + outputs + guidance. Most users should run `preflight`. See [CLI usage](docs/cli.md) for details.
 
 ---
 ## Quickstart


### PR DESCRIPTION
Small README clarification (no code changes).
Keeps docs aligned with current CLI commands.