### PR TITLE
Manifest v1: params_sha256 and versioned dataset_id computation

### DIFF
--- a/tests/test_dataset_id.py
+++ b/tests/test_dataset_id.py
@@ -3,244 +3,126 @@
 
 from hashlib import sha256
 
-import pytest
-
-from fairy.core.services.provenance import compute_dataset_id
-
-
-def test_compute_dataset_id_single_input():
-    """Test dataset_id computation with a single input."""
-    inputs_meta = {
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            "n_cols": 5,
-        }
-    }
-
-    result = compute_dataset_id(inputs_meta)
-
-    # Verify format
-    assert result.startswith("sha256:")
-    assert len(result) == 7 + 64  # "sha256:" + 64 hex chars
-
-    # Verify deterministic: same input produces same hash
-    result2 = compute_dataset_id(inputs_meta)
-    assert result == result2
+from fairy.core.services.provenance import (
+    CANON_VERSION_V1,
+    compute_dataset_id,
+    compute_params_sha256,
+)
 
 
-def test_compute_dataset_id_multiple_inputs_deterministic_ordering():
-    """Test that multiple inputs produce deterministic hash regardless of input order."""
-    inputs_meta1 = {
-        "files": {
-            "sha256": "b" * 64,
-            "n_rows": 3,
-            "n_cols": 3,
+def _expected_v1(
+    *,
+    inputs_sha256: dict[str, str],
+    rulepack: dict[str, str],
+    params_sha256: str,
+    canon_version: str = CANON_VERSION_V1,
+) -> str:
+    # mirror provenance.compute_dataset_id payload exactly
+    import json as _json
+
+    payload = {
+        "canon_version": canon_version,
+        "algorithm": "sha256",
+        "includes": ["inputs.sha256", "rulepack.sha256", "params.sha256"],
+        "inputs": {k: {"sha256": v} for k, v in sorted(inputs_sha256.items())},
+        "rulepack": {
+            "id": rulepack["id"],
+            "version": rulepack["version"],
+            "sha256": rulepack["sha256"],
         },
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            "n_cols": 5,
-        },
+        "params": {"sha256": params_sha256},
     }
-
-    # Same inputs in different order
-    inputs_meta2 = {
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            "n_cols": 5,
-        },
-        "files": {
-            "sha256": "b" * 64,
-            "n_rows": 3,
-            "n_cols": 3,
-        },
-    }
-
-    result1 = compute_dataset_id(inputs_meta1)
-    result2 = compute_dataset_id(inputs_meta2)
-
-    # Should produce same hash because inputs are sorted alphabetically
-    assert result1 == result2
+    canon = _json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    h = sha256(canon.encode("utf-8")).hexdigest()
+    return f"sha256:{h}"
 
 
-def test_compute_dataset_id_canonical_form():
-    """Test that canonical form uses tabs and newlines correctly."""
-    inputs_meta = {
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            "n_cols": 5,
-        }
-    }
+def test_compute_dataset_id_deterministic():
+    inputs_sha256 = {"samples": "a" * 64}
+    rulepack = {"id": "RP", "version": "1.0.0", "sha256": "b" * 64}
+    params_sha = compute_params_sha256(None)
 
-    result = compute_dataset_id(inputs_meta)
-
-    # Manually compute expected hash to verify canonical form
-    canonical_line = f"samples\t{'a' * 64}\t10\t5"
-    expected_hash = sha256(canonical_line.encode("utf-8")).hexdigest()
-    expected_result = f"sha256:{expected_hash}"
-
-    assert result == expected_result
-
-
-def test_compute_dataset_id_multiple_inputs_canonical_form():
-    """Test canonical form with multiple inputs (sorted alphabetically)."""
-    inputs_meta = {
-        "files": {
-            "sha256": "b" * 64,
-            "n_rows": 3,
-            "n_cols": 3,
-        },
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            "n_cols": 5,
-        },
-    }
-
-    result = compute_dataset_id(inputs_meta)
-
-    # Manually compute expected hash (files comes before samples alphabetically)
-    line1 = f"files\t{'b' * 64}\t3\t3"
-    line2 = f"samples\t{'a' * 64}\t10\t5"
-    canonical_string = "\n".join([line1, line2])
-    expected_hash = sha256(canonical_string.encode("utf-8")).hexdigest()
-    expected_result = f"sha256:{expected_hash}"
-
-    assert result == expected_result
-
-
-def test_compute_dataset_id_missing_sha256_with_path(tmp_path):
-    """Test that sha256 is computed automatically from path if missing."""
-    # Create a test file
-    test_file = tmp_path / "test.txt"
-    test_file.write_text("test content", encoding="utf-8")
-
-    # Compute expected sha256
-    from fairy.core.services.provenance import sha256_file
-
-    expected_sha256 = sha256_file(test_file)
-
-    inputs_meta = {
-        "samples": {
-            "path": str(test_file),
-            "n_rows": 10,
-            "n_cols": 5,
-            # sha256 is missing, should be computed from path
-        }
-    }
-
-    result = compute_dataset_id(inputs_meta)
-
-    # Verify it worked by checking the hash includes the computed sha256
-    # The result should be deterministic based on the file content
-    assert result.startswith("sha256:")
-
-    # Verify it's the same as if we provided sha256 directly
-    inputs_meta_with_sha256 = {
-        "samples": {
-            "sha256": expected_sha256,
-            "n_rows": 10,
-            "n_cols": 5,
-        }
-    }
-    result2 = compute_dataset_id(inputs_meta_with_sha256)
-    assert result == result2
-
-
-def test_compute_dataset_id_missing_sha256_no_path():
-    """Test that missing sha256 without path raises ValueError."""
-    inputs_meta = {
-        "samples": {
-            "n_rows": 10,
-            "n_cols": 5,
-            # sha256 and path both missing
-        }
-    }
-
-    with pytest.raises(ValueError, match="lacks sha256 and no path available"):
-        compute_dataset_id(inputs_meta)
-
-
-def test_compute_dataset_id_missing_sha256_nonexistent_path():
-    """Test that missing sha256 with nonexistent path raises FileNotFoundError."""
-    inputs_meta = {
-        "samples": {
-            "path": "/nonexistent/path/to/file.txt",
-            "n_rows": 10,
-            "n_cols": 5,
-        }
-    }
-
-    with pytest.raises((FileNotFoundError, ValueError)) as exc_info:
-        compute_dataset_id(inputs_meta)
-    # Should raise either FileNotFoundError or ValueError with helpful message
-    assert (
-        "nonexistent" in str(exc_info.value).lower()
-        or "does not exist" in str(exc_info.value).lower()
+    r1 = compute_dataset_id(
+        inputs_sha256=inputs_sha256,
+        rulepack=rulepack,
+        params_sha256=params_sha,
+        canon_version=CANON_VERSION_V1,
     )
+    r2 = compute_dataset_id(
+        inputs_sha256=inputs_sha256,
+        rulepack=rulepack,
+        params_sha256=params_sha,
+        canon_version=CANON_VERSION_V1,
+    )
+    assert r1 == r2
+    assert r1.startswith("sha256:")
+    assert len(r1) == 7 + 64
 
 
-def test_compute_dataset_id_missing_n_rows():
-    """Test that missing n_rows raises ValueError."""
-    inputs_meta = {
-        "samples": {
-            "sha256": "a" * 64,
-            "n_cols": 5,
-            # n_rows missing
-        }
-    }
+def test_compute_dataset_id_matches_expected_payload_hash():
+    inputs_sha256 = {"samples": "a" * 64, "files": "c" * 64}
+    rulepack = {"id": "RP", "version": "1.0.0", "sha256": "b" * 64}
+    params_sha = compute_params_sha256({"x": 1, "y": 2})
 
-    with pytest.raises(ValueError, match="lacks n_rows or n_cols"):
-        compute_dataset_id(inputs_meta)
-
-
-def test_compute_dataset_id_missing_n_cols():
-    """Test that missing n_cols raises ValueError."""
-    inputs_meta = {
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            # n_cols missing
-        }
-    }
-
-    with pytest.raises(ValueError, match="lacks n_rows or n_cols"):
-        compute_dataset_id(inputs_meta)
+    got = compute_dataset_id(
+        inputs_sha256=inputs_sha256,
+        rulepack=rulepack,
+        params_sha256=params_sha,
+        canon_version=CANON_VERSION_V1,
+    )
+    exp = _expected_v1(inputs_sha256=inputs_sha256, rulepack=rulepack, params_sha256=params_sha)
+    assert got == exp
 
 
-def test_compute_dataset_id_utf8_handling():
-    """Test that UTF-8 input names are handled correctly."""
-    inputs_meta = {
-        "samples_测试": {  # Chinese characters
-            "sha256": "a" * 64,
-            "n_rows": 10,
-            "n_cols": 5,
-        }
-    }
+def test_compute_dataset_id_changes_if_any_input_sha_changes():
+    inputs1 = {"samples": "a" * 64}
+    inputs2 = {"samples": "d" * 64}  # one byte different effectively
+    rulepack = {"id": "RP", "version": "1.0.0", "sha256": "b" * 64}
+    params_sha = compute_params_sha256({})
 
-    result = compute_dataset_id(inputs_meta)
-    assert result.startswith("sha256:")
-    assert len(result) == 7 + 64
+    r1 = compute_dataset_id(inputs_sha256=inputs1, rulepack=rulepack, params_sha256=params_sha)
+    r2 = compute_dataset_id(inputs_sha256=inputs2, rulepack=rulepack, params_sha256=params_sha)
+    assert r1 != r2
 
 
-def test_compute_dataset_id_zero_rows_cols():
-    """Test that zero rows/cols are handled correctly."""
-    inputs_meta = {
-        "samples": {
-            "sha256": "a" * 64,
-            "n_rows": 0,
-            "n_cols": 0,
-        }
-    }
+def test_compute_dataset_id_changes_if_params_change():
+    inputs = {"samples": "a" * 64}
+    rulepack = {"id": "RP", "version": "1.0.0", "sha256": "b" * 64}
+    p1 = compute_params_sha256({"a": 1})
+    p2 = compute_params_sha256({"a": 2})
 
-    result = compute_dataset_id(inputs_meta)
-    assert result.startswith("sha256:")
+    r1 = compute_dataset_id(inputs_sha256=inputs, rulepack=rulepack, params_sha256=p1)
+    r2 = compute_dataset_id(inputs_sha256=inputs, rulepack=rulepack, params_sha256=p2)
+    assert r1 != r2
 
-    # Verify canonical form includes zeros
-    canonical_line = f"samples\t{'a' * 64}\t0\t0"
-    expected_hash = sha256(canonical_line.encode("utf-8")).hexdigest()
-    expected_result = f"sha256:{expected_hash}"
-    assert result == expected_result
+
+def test_compute_dataset_id_changes_if_rulepack_changes():
+    inputs = {"samples": "a" * 64}
+    params_sha = compute_params_sha256({})
+
+    rp1 = {"id": "RP", "version": "1.0.0", "sha256": "b" * 64}
+    rp2 = {"id": "RP", "version": "1.0.1", "sha256": "b" * 64}
+
+    r1 = compute_dataset_id(inputs_sha256=inputs, rulepack=rp1, params_sha256=params_sha)
+    r2 = compute_dataset_id(inputs_sha256=inputs, rulepack=rp2, params_sha256=params_sha)
+    assert r1 != r2
+
+
+def test_compute_dataset_id_changes_if_canon_version_changes():
+    inputs = {"samples": "a" * 64}
+    rulepack = {"id": "RP", "version": "1.0.0", "sha256": "b" * 64}
+    params_sha = compute_params_sha256({})
+
+    r1 = compute_dataset_id(
+        inputs_sha256=inputs,
+        rulepack=rulepack,
+        params_sha256=params_sha,
+        canon_version="fairy-canon@1",
+    )
+    r2 = compute_dataset_id(
+        inputs_sha256=inputs,
+        rulepack=rulepack,
+        params_sha256=params_sha,
+        canon_version="fairy-canon@2",
+    )
+    assert r1 != r2


### PR DESCRIPTION
Implements Manifest v1 #106 by making dataset identity explicitly versioned and parameter-aware.

Adds canonical params hashing via compute_params_sha256() (hashes {} when params are absent).

Updates dataset fingerprinting to a versioned, config-sensitive computation:

- depends on inputs sha256, rulepack {id, version, sha256}, params_sha256, and canon_version
- does not depend on derived stats like n_rows/n_cols

Introduces RulepackIdentity typed dict to make rulepack identity shape explicit.

## Key Changes
dataset_id will now change if:

- any input file content changes
- rulepack sha/id/version changes
- params change (including {} vs non-empty)
- canon_version changes

dataset_id no longer depends on n_rows/n_cols or parsing artifacts.

## Tests
Updated tests/test_dataset_id.py to cover the new signature and deterministic behavior.
Updated schema/contract tests (tests/test_preflight_report_schema.py) to validate the new dataset_id computation path.