### PR TITLE
cli: print dataset_id in preflight summary

### DIFF
--- a/src/fairy/cli/cmd_preflight.py
+++ b/src/fairy/cli/cmd_preflight.py
@@ -142,6 +142,7 @@ def main(args) -> int:
     print(f"Rulepack:         {rp_id}@{rp_version}")
     print(f"FAIRy version:    {fairy_version}")
     print(f"Generated at:     {report['generated_at']}")
+    print(f"Dataset ID:       {report['dataset_id']}")
 
     # Extract fail/warn codes from results
     fail_codes = sorted({r["rule"] for r in results if r["level"] == "fail"})


### PR DESCRIPTION
Added dataset id into the preflight summary. Helps users copy/paste the fingerprint into emails/tickets and makes it obvious the ID is stable across reruns