### PR TITLE
cli: add preflight geo profile and legacy guidance

### DIFF
--- a/tests/cli/test_cmd_preflight_unit.py
+++ b/tests/cli/test_cmd_preflight_unit.py
@@ -11,6 +11,7 @@ class DummyArgs:
         self.out = out
         self.fairy_version = "0.0.0"
         self.param_file = None
+        self.profile = None
 
 
 def test_preflight_main_emits_files(tmp_path, monkeypatch):
@@ -65,3 +66,78 @@ def test_preflight_main_emits_files(tmp_path, monkeypatch):
     assert rc == 0
     assert out_json.exists()
     assert out_json.with_suffix(".md").exists()
+
+
+def test_preflight_geo_does_not_emit_legacy_guidance(tmp_path, monkeypatch, capsys):
+    out_json = tmp_path / "report.json"
+
+    fake_report = {
+        "dataset_id": "DS123",
+        "generated_at": "2025-11-11T12:00:00Z",
+        "engine": {"fairy_core_version": "0.1.0"},
+        "metadata": {"rulepack": {"id": "RP", "version": "1.0.0"}, "inputs": {}},
+        "summary": {"by_level": {"fail": 0, "warn": 0}},
+        "results": [],
+        "_legacy": {"attestation": {"fairy_version": "0.1.0"}},
+    }
+
+    def fake_run_profile(profile_id: str, *, rulepack, inputs, fairy_version, params=None):
+        assert profile_id == "geo"
+        return fake_report
+
+    def fake_sha256_file(path: Path, newline_stable: bool = True) -> str:
+        return "deadbeef"
+
+    def fake_emit_md(md_path: Path, report: dict, resolved_codes, prior_codes):
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text("# md", encoding="utf-8")
+
+    monkeypatch.setattr("fairy.cli.cmd_preflight.run_profile", fake_run_profile)
+    monkeypatch.setattr("fairy.cli.cmd_preflight.sha256_file", fake_sha256_file)
+    monkeypatch.setattr("fairy.cli.cmd_preflight.emit_preflight_markdown", fake_emit_md)
+
+    args = DummyArgs(out_json)
+    args.profile = "geo"  # NEW: explicit geo path
+    rc = cmd_preflight.main(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "This invocation uses the GEO preflight profile" not in out
+
+
+def test_preflight_legacy_emits_guidance(tmp_path, monkeypatch, capsys):
+    out_json = tmp_path / "report.json"
+
+    fake_report = {
+        "dataset_id": "DS123",
+        "generated_at": "2025-11-11T12:00:00Z",
+        "engine": {"fairy_core_version": "0.1.0"},
+        "metadata": {"rulepack": {"id": "RP", "version": "1.0.0"}, "inputs": {}},
+        "summary": {"by_level": {"fail": 0, "warn": 0}},
+        "results": [],
+        "_legacy": {"attestation": {"fairy_version": "0.1.0"}},
+    }
+
+    def fake_run_profile(profile_id: str, *, rulepack, inputs, fairy_version, params=None):
+        assert profile_id == "geo"
+        return fake_report
+
+    def fake_sha256_file(path: Path, newline_stable: bool = True) -> str:
+        return "deadbeef"
+
+    def fake_emit_md(md_path: Path, report: dict, resolved_codes, prior_codes):
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text("# md", encoding="utf-8")
+
+    monkeypatch.setattr("fairy.cli.cmd_preflight.run_profile", fake_run_profile)
+    monkeypatch.setattr("fairy.cli.cmd_preflight.sha256_file", fake_sha256_file)
+    monkeypatch.setattr("fairy.cli.cmd_preflight.emit_preflight_markdown", fake_emit_md)
+
+    args = DummyArgs(out_json)
+    args.profile = None  # legacy form
+    rc = cmd_preflight.main(args)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "This invocation uses the GEO preflight profile" in out
+    assert "Prefer: fairy preflight geo" in out


### PR DESCRIPTION
## Changes
- Add fairy preflight geo --rulepack ... --samples ... --files ... --out/--out-dir ... that runs the existing GEO TSV workflow.
- Keep legacy fairy preflight --samples ... --files ... working, but emit a non-fatal guidance message pointing to the new geo form.
- Update fairy preflight --help to list available profiles (currently geo) plus legacy note.

Tests
Unit tests cover:

- preflight geo path (no legacy guidance emitted)
- legacy invocation still works and emits guidance

Closes #112 