### PR TITLE
ClI: preflight profiles help and choices

### DIFF
--- a/src/fairy/core/services/validator.py
+++ b/src/fairy/core/services/validator.py
@@ -33,13 +33,8 @@ from ..models.preflight_report_v1 import (
     InputMetadata,
     RulepackMetadata,
 )
-from ..validation_api import (
-    WarningItem,
-    now_utc_iso,
-)
-from ..validation_api import (
-    validate_csv as _core_validate_csv,
-)
+from ..validation_api import WarningItem, now_utc_iso
+from ..validation_api import validate_csv as _core_validate_csv
 from ..validators import rna  # to call check_* helpers
 from .provenance import (
     CANON_VERSION_V1,

--- a/src/fairy/core/validation_api.py
+++ b/src/fairy/core/validation_api.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol
@@ -95,4 +96,7 @@ class Report:
 
 
 def now_utc_iso() -> str:
-    return datetime.now(tz=timezone.utc).isoformat()
+    fixed = os.getenv("FAIRY_FIXED_TIMESTAMP")
+    if fixed:
+        return fixed
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/src/fairy/validation/rulepack_runner.py
+++ b/src/fairy/validation/rulepack_runner.py
@@ -102,7 +102,12 @@ def _read_table(path: Path, delimiter: str | None = None) -> pd.DataFrame:
 
 
 def run_rulepack(
-    inputs_map: dict[str, Path], rulepack: dict, rp_path: Path, now_iso: str
+    inputs_map: dict[str, Path],
+    rulepack: dict,
+    rp_path: Path,
+    now_iso: str,
+    *,
+    params: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     Validate one or more inputs using a rulepack.


### PR DESCRIPTION
Implements the core “profiles” layer for fairy preflight so new workflows can be added without CLI wrappers.

## What changed

Added a profiles registry (get_registry()) with discoverable profile IDs + descriptions.

Introduced a shared runner interface: run_profile(profile_id, rulepack, inputs, fairy_version, params).

Registered starter profiles:

- geo (GEO samples/files TSV runner)
- spellbook (generic validate-style runner stub/initial wiring)

Updated fairy preflight CLI to:

use registry-driven profile choices
render registry-driven Profiles: help text

Added unit tests:
registry lists expected profiles + unknown profile raises ProfileNotFoundError

geo runner passes correct args into validator.run_rulepack (monkeypatched)

## Why

Unblocks adding additional preflight workflows (INSDC/DwC/etc.) with a consistent preflight entrypoint and a discoverable profile list.