### PR TITLE
Core: implement bundle interface, registry, and option merging

### DIFF
--- a/src/fairy/core/services/bundles.py
+++ b/src/fairy/core/services/bundles.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+# -----------------------------
+# Errors
+# -----------------------------
+
+
+class BundleError(RuntimeError):
+    """User-facing bundling errors (unknown format, invalid opts, IO, packager failure)."""
+
+
+# -----------------------------
+# Core types
+# -----------------------------
+
+
+@dataclass(frozen=True)
+class BundleRequest:
+    payload_path: Path
+    artifacts_dir: Path
+    out_dir: Path
+    dataset_id: str | None = None
+
+
+@dataclass(frozen=True)
+class BundleResult:
+    bundle_path: Path
+    format_id: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+class Packager(Protocol):
+    format_id: str
+    description: str | None
+
+    def create_bundle(self, req: BundleRequest, options: Mapping[str, Any]) -> BundleResult: ...
+
+
+@dataclass(frozen=True)
+class BundleFormatSpec:
+    packager: Packager
+    default_options: dict[str, Any] = field(default_factory=dict)
+    description: str | None = None
+
+
+# -----------------------------
+# Registry
+# -----------------------------
+
+
+class BundleRegistry:
+    def __init__(self) -> None:
+        self.__formats: dict[str, BundleFormatSpec] = {}
+
+    def register(self, spec: BundleFormatSpec) -> None:
+        fmt = spec.packager.format_id
+        if not fmt:
+            raise BundleError("Packager format_id must be a non-empty string.")
+        if fmt in self.__formats:
+            raise BundleError(f"Duplicate bundle format: {fmt}")
+        self.__formats[fmt] = spec
+
+    def get(self, format_id: str) -> BundleFormatSpec:
+        try:
+            return self.__formats[format_id]
+        except KeyError as err:
+            available = ", ".join(self.list_format_ids())
+            raise BundleError(
+                f"Unknown bundle format: {format_id}. Available: {available or '(none)'}"
+            ) from err
+
+    def list_format_ids(self) -> list[str]:
+        return sorted(self.__formats.keys())
+
+    def list_formats(self) -> list[tuple[str, str]]:
+        """
+        Returns [(format_id, description)] in stable order for CLI help.
+        """
+        rows: list[tuple[str, str]] = []
+        for fmt in self.list_format_ids():
+            spec = self.__formats[fmt]
+            desc = spec.description or getattr(spec.packager, "description", None) or ""
+            rows.append((fmt, desc))
+        return rows
+
+
+# -----------------------------
+# Singleton registry
+# -----------------------------
+
+BUNDLE_REGISTRY = BundleRegistry()
+
+# -----------------------------
+# Helpers (core invocation logic)
+# -----------------------------
+
+
+def merge_bundle_options(
+    *,
+    defaults: Mapping[str, Any] | None = None,
+    config: Mapping[str, Any] | None = None,
+    cli: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Merge options with precedence:
+        defaults < config < cli
+    """
+    merged: dict[str, Any] = {}
+    if defaults:
+        merged.update(dict(defaults))
+    if config:
+        merged.update(dict(config))
+    if cli:
+        merged.update(dict(cli))
+    return merged
+
+
+def create_bundle(
+    *,
+    format_id: str,
+    payload_path: Path,
+    artifacts_dir: Path,
+    out_dir: Path,
+    dataset_id: str | None = None,
+    config_options: Mapping[str, Any] | None = None,
+    cli_options: Mapping[str, Any] | None = None,
+) -> BundleResult:
+    """
+    Core entry point: resolve packager, merge options, invoke packager.
+    """
+    spec = BUNDLE_REGISTRY.get(format_id)
+
+    req = BundleRequest(
+        payload_path=payload_path,
+        artifacts_dir=artifacts_dir,
+        out_dir=out_dir,
+        dataset_id=dataset_id,
+    )
+
+    options = merge_bundle_options(
+        defaults=spec.default_options,
+        config=config_options,
+        cli=cli_options,
+    )
+
+    try:
+        return spec.packager.create_bundle(req, options)
+    except BundleError:
+        # Already user-facing. re-raise
+        raise
+    except Exception as e:
+        # Wrap unexpected errors so CLI surfaces cleanly
+        raise BundleError(f"Bundle creation failed for format '{format_id}': {e}") from e

--- a/tests/core/test_services/test_bundles_unit.py
+++ b/tests/core/test_services/test_bundles_unit.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from fairy.core.services import bundles
+from fairy.core.services.bundles import BundleError, BundleFormatSpec, BundleResult
+
+
+class FakePackager:
+    format_id = "fake"
+    description = "fake packager for tests"
+
+    def __init__(self, format_id: str = "fake") -> None:
+        self.format_id = format_id
+        self.calls: list[tuple[bundles.BundleRequest, dict[str, Any]]] = []
+
+    def create_bundle(
+        self,
+        req: bundles.BundleRequest,
+        options: Mapping[str, Any],
+    ) -> BundleResult:
+        self.calls.append((req, dict(options)))
+        return BundleResult(
+            bundle_path=req.out_dir / "bundle.fake",
+            format_id=self.format_id,
+            metadata={"called": True},
+        )
+
+
+def _fresh_registry_with_fake(fake: FakePackager) -> bundles.BundleRegistry:
+    reg = bundles.BundleRegistry()
+    reg.register(BundleFormatSpec(packager=fake, default_options={"a": 1, "b": 2}))
+    return reg
+
+
+def test_unknown_format_error_message(monkeypatch, tmp_path):
+    # isolate global registry
+    reg = bundles.BundleRegistry()
+    fake = FakePackager()
+    reg.register(BundleFormatSpec(packager=fake))
+    monkeypatch.setattr(bundles, "BUNDLE_REGISTRY", reg)
+
+    with pytest.raises(BundleError) as excinfo:
+        bundles.create_bundle(
+            format_id="unknown",
+            payload_path=tmp_path / "payload.bin",
+            artifacts_dir=tmp_path / "artifacts",
+            out_dir=tmp_path / "out",
+        )
+
+    msg = str(excinfo.value)
+    assert "Unknown bundle format: unknown" in msg
+    assert "Available: fake" in msg
+
+
+def test_option_precedence_and_request_passthrough(monkeypatch, tmp_path):
+    fake = FakePackager()
+    reg = _fresh_registry_with_fake(fake)
+    monkeypatch.setattr(bundles, "BUNDLE_REGISTRY", reg)
+
+    payload_path = tmp_path / "payload.bin"
+    artifacts_dir = tmp_path / "artifacts"
+    out_dir = tmp_path / "out"
+
+    config_opts = {"b": "config", "c": "config"}
+    cli_opts = {"c": "cli", "d": "cli"}
+
+    result = bundles.create_bundle(
+        format_id="fake",
+        payload_path=payload_path,
+        artifacts_dir=artifacts_dir,
+        out_dir=out_dir,
+        dataset_id="DATASET-123",
+        config_options=config_opts,
+        cli_options=cli_opts,
+    )
+
+    assert fake.calls, "packager was not invoked"
+    ((req, opts),) = fake.calls
+
+    # option precedence: defaults < config < cli
+    assert opts == {"a": 1, "b": "config", "c": "cli", "d": "cli"}
+
+    # request fields are passed through as-is
+    assert req.payload_path == payload_path
+    assert req.artifacts_dir == artifacts_dir
+    assert req.out_dir == out_dir
+    assert req.dataset_id == "DATASET-123"
+
+    # sanity check on result passthrough
+    assert result.bundle_path == out_dir / "bundle.fake"
+    assert result.format_id == "fake"
+    assert result.metadata.get("called") is True
+
+
+def test_register_duplicate_format_id_raises():
+    reg = bundles.BundleRegistry()
+    fake1 = FakePackager()
+    fake2 = FakePackager()
+
+    reg.register(BundleFormatSpec(packager=fake1))
+
+    with pytest.raises(BundleError) as excinfo:
+        reg.register(BundleFormatSpec(packager=fake2))
+
+    assert "Duplicate bundle format: fake" in str(excinfo.value)
+
+
+def test_list_format_ids_and_formats_are_sorted_and_stable():
+    reg = bundles.BundleRegistry()
+    # register in non-sorted order
+    reg.register(BundleFormatSpec(packager=FakePackager("z-format"), description="Z desc"))
+    reg.register(BundleFormatSpec(packager=FakePackager("a-format"), description="A desc"))
+    reg.register(BundleFormatSpec(packager=FakePackager("m-format"), description="M desc"))
+
+    ids = reg.list_format_ids()
+    assert ids == ["a-format", "m-format", "z-format"]
+
+    formats = reg.list_formats()
+    # list_formats should follow the same sorted order
+    assert [fmt for fmt, _ in formats] == ["a-format", "m-format", "z-format"]
+    # and descriptions should match their specs
+    assert formats == [
+        ("a-format", "A desc"),
+        ("m-format", "M desc"),
+        ("z-format", "Z desc"),
+    ]


### PR DESCRIPTION
Introduce the core abstraction layer for FAIRy bundles (supporting Evidence Kits). Includes the packager interface, registry and helpers. Created a FakePackager text.

Closes #82 